### PR TITLE
Fix message type for current limit

### DIFF
--- a/tool_services/gate/TinyJSON/convert.c
+++ b/tool_services/gate/TinyJSON/convert.c
@@ -340,6 +340,7 @@ void Convert_JsonToMsg(service_t *service, uint16_t id, luos_type_t type, const 
     {
         current_t current = ElectricOD_CurrentFrom_A(json_getReal(item));
         ElectricOD_CurrentToMsg(&current, msg);
+        msg->header.cmd = CURRENT_LIMIT;
         Luos_SendMsg(service, msg);
     }
     // target Rotation speed


### PR DESCRIPTION
# PR Checklist 

### _1- PR Comments_

Current limit messages coming from the JSON API are converted by the Gate to messages of type `CURRENT` (in function `ElectricOD_CurrentToMsg`). It prevents these messages from being correctly interpreted by the services, such as servomotor services.

I believe the message type should be `CURRENT_LIMIT`.

<br><hr/>
*WARNING : Do not edit the checklist below.*  
<hr/><br>

### _2- Developer section_

- [x] [Documentation] is up to date with new feature
- [x] [Tests] are *passed OK* (Non regression, new features & bug fixes)
- [x] [Code Quality] Remind to check if :
    * Each function has a header (description, inputs, outputs) 
    * Code is commented (particularly in hard to understand areas)
    * There are no new warnings that can be corrected
    * Commits policy is respected (constitancy commits, clear commits comments)
<hr/><br>

### _3- QA section_

- [x] [Review] tests for new features have been *reviewed*
- [x] [Changelog] is up-to-date with expected tags  
    🆕 Feature: [Feature] Description...  
    🆕 Added: [Feature] Description...  
    🆕 Changed: [Feature] Description...  
    🛠️ Fix: [Feature] Description...  
