### PR TITLE
Do not send void message when receiving a bootloader message

### DIFF
--- a/tool_services/gate/data_manager.c
+++ b/tool_services/gate/data_manager.c
@@ -130,6 +130,7 @@ void DataManager_Format(service_t *service)
     char *data_ptr  = data;
     msg_t *data_msg = 0;
     uint8_t data_ok = false;
+    uint8_t sending = false;
     search_result_t result;
 
     RTFilter_Reset(&result);
@@ -157,6 +158,7 @@ void DataManager_Format(service_t *service)
                 // check if a node send a bootloader message
                 if (data_msg->header.cmd == BOOTLOADER_RESP)
                 {
+                    sending = true;
                     Bootloader_LuosToJson(service, data_msg);
                     continue;
                 }
@@ -211,7 +213,7 @@ void DataManager_Format(service_t *service)
             Convert_EndData(service, data, data_ptr);
             FirstNoReceptionDate = 0;
         }
-        else
+        else if (sending == false)
         {
             // We don't receive anything.
             // After 1s void reception send void data allowing client to send commands (because client could be synchronized to reception).


### PR DESCRIPTION
## PR Description section

### Description and dependencies
When we have received a bootloader message response, we do not send a void message anymore.
This PR prevent the bootloader to crash with the new Pipe developped in 2.6.2.
*  Component: Gate
*  Function: DataManager_Format

## Developer section

- [x] [Documentation] is up to date with new feature
- [x] [Tests] are *passed OK* (non regression, new features & bug fixes)
- [x] [Code Quality] please check if:
    * Each function has a header (description, inputs, outputs) 
    * Code is commented (particularly in hard to understand areas)
    * There are no new warnings that can be corrected
    * Commits policy is respected (constitancy commits, clear commits comments)

## QA section

- [x] [Review] tests for new features have been *reviewed*
- [x] [Changelog] is up-to-date with expected tags  
    🆕 Feature: [Feature] Description...  
    🆕 Added: [Feature] Description...  
    🆕 Changed: [Feature] Description...  
    🛠️ Fix: [Feature] Description...  
