### PR TITLE
[Pipe] Fix pipe size update

### DIFF
--- a/tool_services/pipe/SERIAL/serial_protocol.h
+++ b/tool_services/pipe/SERIAL/serial_protocol.h
@@ -74,7 +74,18 @@ static inline void SerialProtocol_CreateTxMsg(void)
     Stream_PutSample(serialTx_StreamChannel, &SerialProtocol, sizeof(SerialProtocol_t));
 
     // Keep size to update, size are the last 2 bytes of the StreamChannel
-    size_to_update = (uint8_t *)((int)serialTx_StreamChannel->data_ptr - 2);
+    if (serialTx_StreamChannel->data_ptr == serialTx_StreamChannel->ring_buffer)
+    {
+        size_to_update = (uint8_t *)((int)serialTx_StreamChannel->end_ring_buffer - 2);
+    }
+    else if (serialTx_StreamChannel->data_ptr == serialTx_StreamChannel->ring_buffer + serialTx_StreamChannel->data_size)
+    {
+        size_to_update = (uint8_t *)((int)serialTx_StreamChannel->end_ring_buffer - 1);
+    }
+    else
+    {
+        size_to_update = (uint8_t *)((int)serialTx_StreamChannel->data_ptr - 2);
+    }
 }
 
 static inline uint16_t SerialProtocol_GetSizeToSend(void)


### PR DESCRIPTION
By submiting this PR, you agree with the associated license ([Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0) or [MIT](http://choosealicense.com/licenses/mit/)) and with our [Contributor License Agreement](https://github.com/Luos-io/luos_engine/) (CLA).

## Before to begin

Thank you for contributing to the Luos project!

Before to begin, please follow these steps:

- [x] Ensure that this PR is not a duplicate.
- [x] Assign @Simonbdy to this PR


Feel free to read the [Luos contribution's guidelines](https://github.com/Luos-io/luos_engine/blob/main/CONTRIBUTING.md) and the [documentation page](https://www.luos.io/docs/contribute-to-luos) to have more insight about how to contribute to Luos.

## PR Description section

### Description and dependencies
This pr includes a bug fix of the serial protocol used in pipe. Until now we were not checking if the size to update parameter was written in the end of ring buffer in order to find its position in memory when sending the message

### Changes
Please choose the relevant options:

- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s)
*Provide a list of the related issues that will be fixed by this PR.*

---

**WARNING**: Do not edit the checklist below.

---

## Developer section

- [x] [Documentation] is up to date with new feature
- [x] [Tests] are *passed OK* (non regression, new features & bug fixes)
- [x] [Code Quality] please check if:
    * Each function has a header (description, inputs, outputs) 
    * Code is commented (particularly in hard to understand areas)
    * There are no new warnings that can be corrected
    * Commits policy is respected (constitancy commits, clear commits comments)

## QA section

- [x] [Review] tests for new features have been *reviewed*
- [x] [Changelog] is up-to-date with expected tags  
    🆕 Feature: [Feature] Description...  
    🆕 Added: [Feature] Description...  
    🆕 Changed: [Feature] Description...  
    🛠️ Fix: [Feature] Description...  
