### PR TITLE
[bootloader] Do not save the app mode flag when bootloader jumpinto app, fix #381

### DIFF
--- a/engine/bootloader/bootloader_core.c
+++ b/engine/bootloader/bootloader_core.c
@@ -430,7 +430,6 @@ void LuosBootloader_MsgHandler(msg_t *input)
             {
                 // boot the application programmed in dedicated flash partition
                 LuosBootloader_DeInit();
-                LuosHAL_SetMode((uint8_t)JUMP_TO_APP_MODE);
                 LuosBootloader_JumpToApp();
             }
             else

--- a/engine/bootloader/bootloader_core.c
+++ b/engine/bootloader/bootloader_core.c
@@ -350,7 +350,7 @@ void LuosBootloader_MsgHandler(msg_t *input)
 
     switch (bootloader_cmd)
     {
-#ifndef BOOTLOADER
+#ifdef WITH_BOOTLOADER
         case BOOTLOADER_START:
             // We're in the app,
             // set bootloader mode, save node ID and reboot
@@ -358,7 +358,8 @@ void LuosBootloader_MsgHandler(msg_t *input)
             LuosBootloader_SaveNodeID();
             LuosHAL_Reboot();
             break;
-#else
+#endif
+#ifdef BOOTLOADER
             // we're in the bootloader,
             // process cmd and data
         case BOOTLOADER_READY:

--- a/engine/bootloader/bootloader_core.c
+++ b/engine/bootloader/bootloader_core.c
@@ -57,8 +57,6 @@ static inline void LuosBootloader_ProcessData(void);
 static inline void LuosBootloader_SaveLastData(void);
 static void LuosBootloader_SendResponse(bootloader_cmd_t);
 static void LuosBootloader_SendCrc(bootloader_cmd_t, uint8_t);
-#else
-static void LuosBootloader_SaveNodeID(void);
 #endif
 
 /******************************************************************************
@@ -66,12 +64,19 @@ static void LuosBootloader_SaveNodeID(void);
  * @param None
  * @return None
  ******************************************************************************/
-void LuosBootloader_SaveNodeID(void)
+void LuosBootloader_JumpToBootloader(void)
 {
+    // Set bootlaoder mode
+    LuosHAL_SetMode((uint8_t)APP_RELOAD_MODE);
+
+    // Save node id in flash
     node_t *node     = Robus_GetNode();
     uint16_t node_id = node->node_id;
 
     LuosHAL_SaveNodeID(node_id);
+
+    // Reset the MCU
+    LuosHAL_Reboot();
 }
 
 #ifdef BOOTLOADER
@@ -354,9 +359,7 @@ void LuosBootloader_MsgHandler(msg_t *input)
         case BOOTLOADER_START:
             // We're in the app,
             // set bootloader mode, save node ID and reboot
-            LuosHAL_SetMode((uint8_t)APP_RELOAD_MODE);
-            LuosBootloader_SaveNodeID();
-            LuosHAL_Reboot();
+            LuosBootloader_JumpToBootloader();
             break;
 #endif
 #ifdef BOOTLOADER

--- a/engine/bootloader/bootloader_core.h
+++ b/engine/bootloader/bootloader_core.h
@@ -65,5 +65,8 @@ void LuosBootloader_Loop(void);
  * @brief function used by Luos to send message to the bootloader
  ******************************************************************************/
 void LuosBootloader_MsgHandler(msg_t *);
+#ifndef BOOTLOADER
+void LuosBootloader_JumpToBootloader(void);
+#endif
 
 #endif /* BOOTLOADER_H */

--- a/engine/core/src/luos_engine.c
+++ b/engine/core/src/luos_engine.c
@@ -37,10 +37,6 @@ service_t *detection_service;
 luos_stats_t luos_stats;
 general_stats_t general_stats;
 
-bool launch_boot_flag    = true;
-bool boot_run            = false;
-uint32_t boot_start_date = 0;
-
 /*******************************************************************************
  * Function
  ******************************************************************************/
@@ -89,17 +85,15 @@ void Luos_Loop(void)
     msg_t *returned_msg             = NULL;
 
 #ifdef WITH_BOOTLOADER
-    if (launch_boot_flag)
+    // After 3 Luos_Loop, consider this application as safe and write a flag to let the booloader know it can jump to the application safely.
+    static uint8_t loop_count = 0;
+    if (loop_count < 3)
     {
-        launch_boot_flag = false;
-        boot_start_date  = LuosHAL_GetSystick();
-        boot_run         = true;
-    }
-
-    if (((LuosHAL_GetSystick() - boot_start_date) > BOOT_TIMEOUT) && boot_run)
-    {
-        LuosHAL_SetMode((uint8_t)JUMP_TO_APP_MODE);
-        boot_run = false;
+        loop_count++;
+        if (loop_count == 3)
+        {
+            LuosHAL_SetMode((uint8_t)JUMP_TO_APP_MODE);
+        }
     }
 #endif
 

--- a/engine/core/src/luos_utils.c
+++ b/engine/core/src/luos_utils.c
@@ -11,6 +11,9 @@
 #include "luos_hal.h"
 #include "msg_alloc.h"
 #include "stdbool.h"
+#ifdef WITH_BOOTLOADER
+    #include "bootloader_core.h"
+#endif
 
 /*******************************************************************************
  * Function
@@ -54,6 +57,13 @@ _CRITICAL __attribute__((weak)) void Luos_assert(char *file, uint32_t line)
     // wait for the transmission to finish before killing IRQ
     while (MsgAlloc_TxAllComplete() == FAILED)
         ;
+#ifdef WITH_BOOTLOADER
+    // We're in a failed app,
+    // Restart this node in bootloader mode instead of don't do anything
+    // We will come back on this app after a reboot.
+    // Set bootloader mode, save node ID and reboot
+    LuosBootloader_JumpToBootloader();
+#endif
     LuosHAL_SetIrqState(false);
     while (1)
     {


### PR DESCRIPTION
## PR Description section
Do not save the app mode when bootloader jump, let the applicative Luos_engine write it instead

### Changes
Please choose the relevant options:

- [X] Bug fix (non-breaking change which fixes an issue)
### Related issue(s)
*Provide a list of the related issues that will be fixed by this PR.*

---

**WARNING**: Do not edit the checklist below.

---

## Developer section

- [x] [Documentation] is up to date with new feature
- [x] [Tests] are *passed OK* (non regression, new features & bug fixes)
- [x] [Code Quality] please check if:
    * Each function has a header (description, inputs, outputs) 
    * Code is commented (particularly in hard to understand areas)
    * There are no new warnings that can be corrected
    * Commits policy is respected (constitancy commits, clear commits comments)

## QA section

- [x] [Review] tests for new features have been *reviewed*
- [x] [Changelog] is up-to-date with expected tags  
    🆕 Feature: [Feature] Description...  
    🆕 Added: [Feature] Description...  
    🆕 Changed: [Feature] Description...  
    🛠️ Fix: [Feature] Description...  
