### PR TITLE
Manage COM Port number greater than COM9

### DIFF
--- a/network/serial_network/HAL/NATIVE/serial_network_hal.c
+++ b/network/serial_network/HAL/NATIVE/serial_network_hal.c
@@ -185,8 +185,10 @@ void SerialHAL_Init(uint8_t *rx_buffer, uint32_t buffer_size)
 
 // Open the serial port
 #ifdef _WIN32
+    char tmp[128];
+    sprintf(tmp, "\\\\.\\%s", portname);
     hSerial = CreateFile(
-        portname,
+        tmp,
         GENERIC_READ | GENERIC_WRITE,
         0,    // exclusive access
         NULL, // no security


### PR DESCRIPTION
## PR Description section
Add \\\\.\\ to portname for serial_network on windows.

### Description and dependencies
Modify portname before calling CreateFile function in serial_network_hal.c file

### Changes
- [x] Bug fix (non-breaking change which fixes an issue)

Before it was impossible to Init the serial network with COM Port number greater than 9

### Related issue(s)

Connection on serial port COM11 at 1000000 baud
CreateFile failed with error 2.

---

**WARNING**: Do not edit the checklist below.

---

## Developer section

- [x] [Documentation] is up to date with new feature
- [x] [Tests] are *passed OK* (non regression, new features & bug fixes)
- [x] [Code Quality] please check if:
    * Each function has a header (description, inputs, outputs) 
    * Code is commented (particularly in hard to understand areas)
    * There are no new warnings that can be corrected
    * Commits policy is respected (constitancy commits, clear commits comments)

## QA section

- [x] [Review] tests for new features have been *reviewed*
- [x] [Changelog] is up-to-date with expected tags  
    🆕 Feature: [Feature] Description...  
    🆕 Added: [Feature] Description...  
    🆕 Changed: [Feature] Description...  
    🛠️ Fix: [Feature] Description...  
