### PR TITLE
fix streaming channel ring buffer chunck management

### DIFF
--- a/engine/core/src/streaming.c
+++ b/engine/core/src/streaming.c
@@ -62,7 +62,7 @@ uint32_t Streaming_PutSample(streaming_channel_t *stream, const void *data, uint
     if (((size * stream->data_size) + (uintptr_t)stream->data_ptr) >= (uintptr_t)stream->end_ring_buffer)
     {
         // our data exceeds ring buffer end, cut it and copy.
-        uint32_t chunk1 = (uintptr_t)stream->end_ring_buffer - (uintptr_t)stream->data_ptr;
+        uint32_t chunk1 = (uintptr_t)stream->end_ring_buffer - (uintptr_t)stream->data_ptr + stream->data_size;
         uint32_t chunk2 = (size * stream->data_size) - chunk1;
         // Everything good copy datas.
         memcpy(stream->data_ptr, data, chunk1);
@@ -97,8 +97,8 @@ uint32_t Streaming_GetSample(streaming_channel_t *stream, void *data, uint32_t s
         if ((stream->sample_ptr + (size * stream->data_size)) > stream->end_ring_buffer)
         {
             // requested data exceeds ring buffer end, cut it and copy.
-            int chunk1 = stream->end_ring_buffer - stream->sample_ptr;
-            int chunk2 = (size * stream->data_size) - chunk1;
+            uint32_t chunk1 = stream->end_ring_buffer - stream->sample_ptr + stream->data_size;
+            uint32_t chunk2 = (size * stream->data_size) - chunk1;
             memcpy(data, stream->sample_ptr, chunk1);
             memcpy((char *)data + chunk1, stream->ring_buffer, chunk2);
             // Set the new sample pointer
@@ -170,7 +170,7 @@ uint32_t Streaming_AddAvailableSampleNB(streaming_channel_t *stream, uint32_t si
     LUOS_ASSERT((int32_t)(total_sample_capacity - Streaming_GetAvailableSampleNB(stream) - size) > 0);
     if (((size * stream->data_size) + stream->data_ptr) >= stream->end_ring_buffer)
     {
-        uint32_t chunk1  = (uintptr_t)stream->end_ring_buffer - (uintptr_t)stream->data_ptr;
+        uint32_t chunk1  = (uintptr_t)stream->end_ring_buffer - (uintptr_t)stream->data_ptr + stream->data_size;
         uint32_t chunk2  = (size * stream->data_size) - chunk1;
         stream->data_ptr = (void *)((uintptr_t)stream->ring_buffer + chunk2);
     }
@@ -195,7 +195,7 @@ uint32_t Streaming_RmvAvailableSampleNB(streaming_channel_t *stream, uint32_t si
     if (((size * stream->data_size) + stream->sample_ptr) > stream->end_ring_buffer)
     {
         // We exceed ring buffer end.
-        uint32_t chunk1    = (uintptr_t)stream->end_ring_buffer - (uintptr_t)stream->sample_ptr;
+        uint32_t chunk1    = (uintptr_t)stream->end_ring_buffer - (uintptr_t)stream->sample_ptr + stream->data_size;
         uint32_t chunk2    = (size * stream->data_size) - chunk1;
         stream->sample_ptr = (void *)((uintptr_t)stream->ring_buffer + chunk2);
     }


### PR DESCRIPTION
By submiting this PR, you agree with the associated license [MIT](http://choosealicense.com/licenses/mit/)) and with our [Contributor License Agreement](https://github.com/Luos-io/luos_engine/) (CLA).

## Before to begin

Thank you for contributing to the Luos project!

Before to begin, please follow these steps:

- [ ] Ensure that this PR is not a duplicate.
- [ ] Assign @Simonbdy to this PR
- [ ] Add the PR to the `Luos contribution project`

Feel free to read the [Luos contribution's guidelines](https://github.com/Luos-io/luos_engine/blob/main/CONTRIBUTING.md) and the [documentation page](https://www.luos.io/docs/contribute-to-luos) to have more insight about how to contribute to Luos.

## PR Description section
In streaming.c, in the case data does not fit remaining space in the ring buffer, it seems that the chunck1 computation is false and missing the last slot of the buffer. That leads to an "empty" slot in the buffer that is  later considered as data.

### Description and dependencies
*Please include here a summary of the changes and the related issue. List any dependencies that are required for this change.* 

### Changes
Please choose the relevant options:

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Related issue(s)
*Provide a list of the related issues that will be fixed by this PR.*

---

**WARNING**: Do not edit the checklist below.

---

## Developer section

- [ ] [Documentation] is up to date with new feature
- [ ] [Tests] are *passed OK* (non regression, new features & bug fixes)
- [ ] [Code Quality] please check if:
    * Each function has a header (description, inputs, outputs) 
    * Code is commented (particularly in hard to understand areas)
    * There are no new warnings that can be corrected
    * Commits policy is respected (constitancy commits, clear commits comments)

## QA section

- [ ] [Review] tests for new features have been *reviewed*
- [ ] [Changelog] is up-to-date with expected tags  
    🆕 Feature: [Feature] Description...  
    🆕 Added: [Feature] Description...  
    🆕 Changed: [Feature] Description...  
    🛠️ Fix: [Feature] Description...  
