### PR TITLE
Fix PlatformIO deployment: bump Pipe, robus, and serial versions

### DIFF
--- a/network/robus_network/library.json
+++ b/network/robus_network/library.json
@@ -2,7 +2,7 @@
     "name": "robus_network",
     "keywords": "robus,network,microservice,luos,operating system,os,embedded,communication,service",
     "description": "A very handy half duplex serial network interface specialy crafted and optimized for Luos.",
-    "version": "3.0.0",
+    "version": "3.1.0",
     "authors": {
         "name": "Luos",
         "url": "https://luos.io"
@@ -14,7 +14,7 @@
         "extraScript": "robus_select_hal_script.py"
     },
     "dependencies": {
-        "luos_engine": "^3.0.0"
+        "luos_engine": "^3.1.0"
     },
     "repository": {
         "type": "git",

--- a/network/serial_network/library.json
+++ b/network/serial_network/library.json
@@ -2,7 +2,7 @@
     "name": "serial_network",
     "keywords": "serial,network,microservice,luos,operating system,os,embedded,communication,service,ST,cJSON",
     "description": "A serial network interface dedicated to Luos.",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "authors": {
         "name": "Luos",
         "url": "https://luos.io"
@@ -14,7 +14,7 @@
         "extraScript": "serial_select_hal_script.py"
     },
     "dependencies": {
-        "luos_engine": "^3.0.0"
+        "luos_engine": "^3.1.0"
     },
     "repository": {
         "type": "git",

--- a/network/ws_network/library.json
+++ b/network/ws_network/library.json
@@ -15,7 +15,7 @@
     },
     "dependencies": {
         "SPI": "^1.0",
-        "luos_engine": "^3.0.0",
+        "luos_engine": "^3.1.0",
         "WiFi101": "^0.16.1",
         "arduino-libraries/ArduinoHttpClient": "^0.5.0"
     },

--- a/network/ws_network/library.json
+++ b/network/ws_network/library.json
@@ -2,7 +2,7 @@
     "name": "ws_network",
     "keywords": "ws, websocket,network,microservice,luos,operating system,os,embedded,communication,service",
     "description": "A websocket network interface dedicated to Luos.",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "authors": {
         "name": "Luos",
         "url": "https://luos.io"

--- a/tool_services/pipe/library.json
+++ b/tool_services/pipe/library.json
@@ -2,7 +2,7 @@
     "name": "Pipe",
     "keywords": "robus,network,microservice,luos,operating system,os,embedded,communication,service,ST,cJSON",
     "description": "A driver to communicate with the outside world.",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "authors": {
         "name": "Luos",
         "url": "https://luos.io"


### PR DESCRIPTION
## Summary
- PlatformIO deployment failed for `Pipe`, `robus_network`, and `serial_network` after the RC 3.1.0 merge (#458) because their versions were not bumped despite having code changes
- **robus_network**: `3.0.0` → `3.1.0` (HAL changes across all platforms, PTP fix after reset on STM32G4, infinite collision fix)
- **serial_network**: `1.0.0` → `1.1.0` (new STM32L476 HAL, COM port > COM9 fix, native HAL byte count/delay fix)
- **Pipe**: `2.0.0` → `2.1.0` (new STM32L476 pipe_com HAL, serial_protocol.h update)
- **ws_network**: dependency updated from `luos_engine@^3.0.0` to `^3.1.0`
- All example projects already reference correct versions (luos_engine@^3.1.0 via library.json, local libs via lib_extra_dirs)

## Test plan
- [ ] Verify PlatformIO deployment workflow (`pio_release.yml`) succeeds for all 5 libraries
- [ ] Verify example projects still build correctly via CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)